### PR TITLE
Bug Fix: build_menu_bar

### DIFF
--- a/application/helpers/common_helper.php
+++ b/application/helpers/common_helper.php
@@ -67,7 +67,7 @@ function build_menu_bar($choices)
 {
     $result = '<ul>';
     foreach ($choices as $name => $link)
-	$result .= '<li>' . anchor($link, $name) . '</ul>';
+	$result .= '<li>' . anchor($link, $name) . '</li>';
     $result .= '</ul>';
     return $result;
 }


### PR DESCRIPTION
Typo in build_menu_bar(). Closing tag for individual menu elements closed the unordered list, not the list item.
